### PR TITLE
Make metar_get_historical compatible with ogimet cgi bin

### DIFF
--- a/R/metar_get_historical.R
+++ b/R/metar_get_historical.R
@@ -91,14 +91,10 @@ metar_get_historical <- function(airport = "EPWA",
     eyear <- stringr::str_sub(end_date, 1, 4)
     emonth <- stringr::str_sub(end_date, 6, 7)
     eday <- stringr::str_sub(end_date, 9, 10)
-    link <- paste0("www.ogimet.com/display_metars2.php?lang=en&lugar=",
-                   airport,"&tipo=SA&ord=DIR&nil=NO&fmt=txt&ano=",
-                   syear, "&mes=",
-                   smonth, "&day=",
-                   sday, "&hora=00&anof=",
-                   eyear, "&mesf=",
-                   emonth, "&dayf=",
-                   eday, "&horaf=23&minf=59&enviar=Ver")
+    link <- paste0("www.ogimet.com/cgi-bin/getmetar?icao=",
+                   airport,"&begin=",
+                   paste0(syear,smonth,sday,"0000"), "&end=",
+                   paste0(eyear,emonth,eday,"2359"))
     message("Getting information from Weather Information Service http://www.ogimet.com/")
     message("developed by Guillermo Ballester Valor")
   } else if(from == "iastate"){
@@ -163,29 +159,13 @@ metar_get_historical <- function(airport = "EPWA",
       }
     }
   )
-
-  ds <- utils::read.csv((textConnection(myfile)), stringsAsFactors = FALSE)
+  
+  header <- from != "ogimet"
+  ds <- utils::read.csv((textConnection(myfile)), header=header, stringsAsFactors = FALSE)
 
   if(from == "ogimet"){
-    text_pattern <- paste("#  METAR/SPECI from", airport)
-    ids <- which(ds[,1] == text_pattern) + 2
-    ide <- which(ds[,1] == "</pre>") - 1
-    ds <- as.data.frame(ds[ids:ide,1], stringsAsFactors = FALSE)
-    colnames(ds) <- c("x")
-    pattern <- "^[\\d]+\\s(?:METAR|SPECI)"
-    ds$x <- stringr::str_trim(ds$x)
-    idd <- stringr::str_detect(ds$x, pattern = pattern)
-    i <- 1
-    out <- data.frame(metar = "empty", stringsAsFactors = FALSE)
-    metartext <- "empty"
-    while(i < length(idd)){
-      if(idd[i]){
-        out <- rbind(out, metartext)
-        metartext <- ds[i,1]
-      } else metartext <- paste(metartext, ds[i,1])
-      i <- i + 1
-    }
-    out <- out[3:nrow(out),]
+    ds[,6] <- stringr::str_c(ds$V2,ds$V3,ds$V4,ds$V5,ds$V6)
+    out <- paste(ds[,6], ds[,7],sep=" ")
   } else {
     ds[,2] <- stringr::str_replace_all(ds[,2], "[[:punct:]]", "")
     ds[,2] <- stringr::str_replace_all(ds[,2], " ", "")


### PR DESCRIPTION
Hi Pawel,

I attempted to use metar_get_historical() with ogimet as the source, but the function no longer returns data, the URL generated by the current implementation appears to be incompatible with recent changes in how the OGIMET site serves historical METARs. 

However, OGIMET provides a CGI endpoint that returns raw METAR reports in CSV format, documented here:
https://www.ogimet.com/getmetar_help.phtml.en . This interface is more suitable for automated retrieval than the URL generated by the existing implementation of display_metars2.php. I have therefore modified the function to use this CGI directly.

Note that the returned dataset is limited to 200 000 METAR records per request; I have preserved the existing limit logic in the function for now, but it may be worth revisiting.

Thank you for considering this pull request.

Nicolas