### PR TITLE
Getmetarcgibin

### DIFF
--- a/R/metar_get_historical.R
+++ b/R/metar_get_historical.R
@@ -161,7 +161,7 @@ metar_get_historical <- function(airport = "EPWA",
   )
   
   header <- from != "ogimet"
-  ds <- utils::read.csv((textConnection(myfile)), header=header, stringsAsFactors = FALSE)
+  ds <- utils::read.csv((textConnection(myfile)), header=header, colClasses = "character", stringsAsFactors = FALSE)
 
   if(from == "ogimet"){
     ds[,6] <- stringr::str_c(ds$V2,ds$V3,ds$V4,ds$V5,ds$V6)


### PR DESCRIPTION
Hi Pawel,

I attempted to use metar_get_historical() with ogimet as the source, but the function no longer returns data — the URL generated by the current implementation appears to be incompatible with recent changes in how the OGIMET site serves historical METARs.

However, OGIMET provides a CGI endpoint that returns raw METAR reports in CSV format, documented here: https://www.ogimet.com/getmetar_help.phtml.en
This interface is more suitable for automated retrieval than the URL generated by the existing implementation of display_metars2.php. I have therefore modified the function to use this CGI directly.

Note that the returned dataset is limited to 200 000 METAR records per request; I have preserved the existing limit logic in the function for now, but it may be worth revisiting.

Thank you for considering this pull request.